### PR TITLE
Minor adjustments to 1.60 fixes, Linux 4.7 compatibility

### DIFF
--- a/ndiswrapper/driver/.gitignore
+++ b/ndiswrapper/driver/.gitignore
@@ -1,0 +1,11 @@
+*.ko
+*.mod.c
+*.o
+.*.cmd
+*_exports.h
+/.tmp_versions/
+/Module.markers
+/Module.symvers
+/modules.order
+/ndis_exports.h
+/win2lin_stubs.h

--- a/ndiswrapper/driver/ntoskernel.h
+++ b/ndiswrapper/driver/ntoskernel.h
@@ -46,10 +46,8 @@
 #include <linux/percpu.h>
 #include <linux/kthread.h>
 #include <linux/workqueue.h>
-
-#if LINUX_VERSION_CODE > KERNEL_VERSION(4,0,0)
 #include <linux/vmalloc.h>
-#endif
+
 
 #if !defined(CONFIG_X86) && !defined(CONFIG_X86_64)
 #error "this module is for x86 or x86_64 architectures only"

--- a/ndiswrapper/driver/ntoskernel.h
+++ b/ndiswrapper/driver/ntoskernel.h
@@ -360,8 +360,11 @@ static inline void reinit_completion(struct completion *x)
 #define prandom_seed(seed) net_srandom(seed)
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
-#define strncasecmp strnicmp
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22)
+static int strncasecmp(const char *s1, const char *s2, size_t n)
+{
+	strnicmp(s1, s2, n);
+}
 #endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,7,0)

--- a/ndiswrapper/driver/ntoskernel.h
+++ b/ndiswrapper/driver/ntoskernel.h
@@ -366,6 +366,13 @@ static inline void reinit_completion(struct completion *x)
 #define strncasecmp strnicmp
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,7,0)
+static inline void netif_trans_update(struct net_device *dev)
+{
+	dev->trans_start = jiffies;
+}
+#endif
+
 /* TICK is 100ns */
 #define TICKSPERSEC		10000000
 #define TICKSPERMSEC		10000

--- a/ndiswrapper/driver/wrapndis.c
+++ b/ndiswrapper/driver/wrapndis.c
@@ -704,7 +704,7 @@ static void tx_worker(struct work_struct *work)
 			n = wnd->max_tx_packets;
 		n = mp_tx_packets(wnd, wnd->tx_ring_start, n);
 		if (n) {
-			wnd->net_dev->trans_start = jiffies;
+			netif_trans_update(wnd->net_dev);
 			wnd->tx_ring_start =
 				(wnd->tx_ring_start + n) % TX_RING_SIZE;
 			wnd->is_tx_ring_full = 0;

--- a/ndiswrapper/utils/.gitignore
+++ b/ndiswrapper/utils/.gitignore
@@ -1,0 +1,1 @@
+/loadndisdriver


### PR DESCRIPTION
I was finally able to review the changes made to version 1.60. They are good, all supported kernel versions compile. But I made some changes to make the code look better. I also fixed compatibility with the forthcoming Linux 4.7. Finally, I added .gitignore files, as the project is in git now.
